### PR TITLE
bug fix - project id with more than 2 digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,31 +76,27 @@ Licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) Lice
 
 ## Changelog
 
--   **1.2.4**
+- **1.2.5**:
+  - **Bug fix** for project numbers with more than 2 digits.
 
-    Support agent all_services as parameter of telemetry_list
+- **1.2.4**:
+  - Support agent all_services as parameter of telemetry_list.
 
--   **1.2.3**
+- **1.2.3**:
+  - Add prefix to the function name
 
-    Add prefix to the function name
+- **1.2.2**:
+  - Rename param from `resource_list` to `telemetry_list`
 
--   **1.2.2**
+- **1.2.1**:
+  - Add function that user can choose project id where need to run integration
 
-    Rename param from `resource_list` to `telemetry_list`
+- **1.2.0**:
+  - Replace location of the cloud function from cloud storage to local 
+  - Replace trigger function from HTTP to pubsub trigger
 
--   **1.2.1**
+- **1.1.0**:
+  - Replace sink filter to google cloud resource type
 
-    Add function that user can choose project id where need to run integration
-
--   **1.2.0**
-
-    Replace location of the cloud function from cloud storage to local
-    Replace trigger function from HTTP to pubsub trigger
-
--   **1.1.0**
-
-    Replace sink filter to google cloud resource type
-
--   **1.0.0**
-
-    Initial Release
+- **1.0.0**:
+  - Initial Release

--- a/run.sh
+++ b/run.sh
@@ -279,7 +279,7 @@ function _choose_and_set_project_id(){
         echo "[$count]:  $project"
         array_projects+=("$project")
     done
-    read -n 2 -p "Please fill in number of project where you would like the integration to be deployed in: " mainmenuinput
+    read -p "Please fill in number of project where you would like the integration to be deployed in: " mainmenuinput
     count_projects=0
     for value in "${array_projects[@]}"
     do


### PR DESCRIPTION
Currently, only the first 2 digits of a project id are being passed. This causes a bug for projects that have more than 2 digits. This PR should solve it.