### PR TITLE
Fix multiple resource types

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -148,7 +148,7 @@ function populate_filter_for_service_name(){
 	    fi
     # or do whatever with individual element of the array
     done
-	telemetry_list=$filter
+	telemetry_list="(${filter})"
     fi
 	
     if [[ $filter == *"all_services"* ]]; then

--- a/run.sh
+++ b/run.sh
@@ -133,7 +133,7 @@ function check_validation () {
 
 function populate_filter_for_service_name(){
     if [[ ! -z "$telemetry_list" ]]; then
-	filter=" AND"
+	filter=" OR"
 	array_filter_names=(${telemetry_list//,/ })
 
 	last_element=${#array_filter_names[@]}
@@ -144,7 +144,7 @@ function populate_filter_for_service_name(){
 	    if [ $current -eq $last_element ]; then
 	        filter+=" resource.type=${name}"
         else
-	        filter+=" resource.type=${name} AND"
+	        filter+=" resource.type=${name} OR"
 	    fi
     # or do whatever with individual element of the array
     done


### PR DESCRIPTION
The AND operator in condition is invalid since it tries to filter the resource type with different values which doesn't exist in a single log. The condition should use OR operation logic to support querying per resource type.